### PR TITLE
Add blog infrastructure (no posts yet)

### DIFF
--- a/src/components/blog/BlogCoverImage.astro
+++ b/src/components/blog/BlogCoverImage.astro
@@ -1,0 +1,33 @@
+---
+import { Image } from "astro:assets";
+
+interface Props {
+  src: string;
+  alt: string;
+  caption?: string;
+}
+
+const { src, alt, caption } = Astro.props;
+---
+
+<figure class="my-8">
+  <div
+    class="relative aspect-video overflow-hidden rounded-lg border border-[#ffffff10] bg-[#0c0c0c]"
+  >
+    <Image
+      src={src}
+      alt={alt}
+      width={1200}
+      height={675}
+      class="w-full h-full object-cover"
+      loading="eager"
+    />
+  </div>
+  {
+    caption && (
+      <figcaption class="mt-2 text-xs text-[var(--white-icon)] text-center">
+        {caption}
+      </figcaption>
+    )
+  }
+</figure>

--- a/src/components/blog/BlogHeader.astro
+++ b/src/components/blog/BlogHeader.astro
@@ -1,0 +1,50 @@
+---
+interface Props {
+  active?: "blog" | "home";
+}
+
+const { active = "blog" } = Astro.props;
+---
+
+<header
+  class="fixed top-0 left-0 right-0 z-50 border-b border-[#ffffff10] bg-[var(--background)]/90 backdrop-blur-md"
+>
+  <nav
+    class="max-w-3xl mx-auto flex items-center justify-between py-4 px-4 sm:px-6 min-h-[var(--nav-height)]"
+  >
+    <a
+      href="/"
+      class="text-[var(--sec)] font-bold text-2xl hover:opacity-80 transition-opacity duration-300"
+    >
+      AV
+    </a>
+    <ul class="flex items-center gap-6 list-none m-0 p-0">
+      <li>
+        <a
+          href="/"
+          class:list={[
+            "text-sm transition-colors duration-300",
+            active === "home"
+              ? "text-[var(--sec)]"
+              : "text-[var(--white-icon)] hover:text-[var(--sec)]",
+          ]}
+        >
+          Portfolio
+        </a>
+      </li>
+      <li>
+        <a
+          href="/blog/"
+          class:list={[
+            "text-sm transition-colors duration-300",
+            active === "blog"
+              ? "text-[var(--sec)]"
+              : "text-[var(--white-icon)] hover:text-[var(--sec)]",
+          ]}
+        >
+          Blog
+        </a>
+      </li>
+    </ul>
+  </nav>
+</header>

--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -1,0 +1,59 @@
+---
+import TagPills from "@/components/blog/TagPills.astro";
+import type { BlogPost } from "@/lib/blog-tags";
+
+interface Props {
+  post: BlogPost;
+}
+
+const { post } = Astro.props;
+const formattedDate = post.data.pubDate.toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+---
+
+<article
+  class="border border-[#ffffff10] rounded-lg overflow-hidden hover:border-[var(--sec)]/40 transition-colors duration-300"
+>
+  {
+    post.data.cover && (
+      <a
+        href={`/blog/${post.id}/`}
+        class="block aspect-video overflow-hidden bg-[#0c0c0c]"
+        aria-hidden="true"
+        tabindex="-1"
+      >
+        <img
+          src={post.data.cover.src}
+          alt=""
+          class="w-full h-full object-cover transition-transform duration-300 hover:scale-[1.02]"
+          loading="lazy"
+          width={800}
+          height={450}
+        />
+      </a>
+    )
+  }
+  <div class="p-6">
+  <time
+    datetime={post.data.pubDate.toISOString()}
+    class="text-xs text-[var(--white-icon)]"
+  >
+    {formattedDate}
+  </time>
+  <h2 class="mt-2 mb-2 text-xl font-bold">
+    <a
+      href={`/blog/${post.id}/`}
+      class="text-[var(--white)] hover:text-[var(--sec)] transition-colors duration-300"
+    >
+      {post.data.title}
+    </a>
+  </h2>
+  <p class="text-[var(--white-icon)] text-sm mb-4 leading-relaxed">
+    {post.data.description}
+  </p>
+  <TagPills tags={post.data.tags} />
+  </div>
+</article>

--- a/src/components/blog/TagPills.astro
+++ b/src/components/blog/TagPills.astro
@@ -1,0 +1,24 @@
+---
+import { formatTagLabel, tagUrl } from "@/lib/blog-tags";
+
+interface Props {
+  tags: string[];
+}
+
+const { tags } = Astro.props;
+---
+
+<ul class="flex flex-wrap gap-2 list-none p-0 m-0">
+  {
+    tags.map((tag) => (
+      <li>
+        <a
+          href={tagUrl(tag)}
+          class="inline-block px-3 py-1 text-xs border border-[var(--sec)] text-[var(--sec)] rounded-full hover:bg-[var(--white-icon-tr)] transition-colors duration-300"
+        >
+          {formatTagLabel(tag)}
+        </a>
+      </li>
+    ))
+  }
+</ul>

--- a/src/components/sections/Footer.astro
+++ b/src/components/sections/Footer.astro
@@ -73,6 +73,13 @@ import { footerSocialLinks } from "@/data/social-links";
             >Anderson Vanegas</a
           >. All rights reserved.
         </span>
+        <span class="block sm:inline sm:ml-2">
+          <a
+            href="/blog/"
+            class="hover:text-[var(--sec)] transition-all duration-300"
+            >Blog</a
+          >
+        </span>
       </p>
     </div>
   </div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,25 @@
+import { defineCollection } from "astro:content";
+import { glob } from "astro/loaders";
+import { z } from "astro/zod";
+
+const blog = defineCollection({
+  loader: glob({
+    pattern: "**/[^_]*.{md,mdx}",
+    base: "./src/content/blog",
+  }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.coerce.date(),
+    tags: z.array(z.string().min(1)).min(1).max(4),
+    featured: z.boolean().default(false),
+    cover: z
+      .object({
+        src: z.string(),
+        alt: z.string(),
+      })
+      .optional(),
+  }),
+});
+
+export const collections = { blog };

--- a/src/data/blog-images.ts
+++ b/src/data/blog-images.ts
@@ -1,0 +1,5 @@
+/** Shared blog image paths (files live in public/images/). */
+export const blogPlaceholderCover = {
+  src: "/images/blog-placeholder.jpg",
+  alt: "Placeholder cover image for blog posts",
+} as const;

--- a/src/data/blog-tags.ts
+++ b/src/data/blog-tags.ts
@@ -1,0 +1,61 @@
+/**
+ * Reference tag list for blog posts. Not enforced at build time —
+ * reuse these slugs before inventing new ones.
+ */
+export const suggestedBlogTags = [
+  {
+    slug: "qa",
+    label: "QA",
+    description: "Quality assurance practices and mindset",
+  },
+  {
+    slug: "automation",
+    label: "Automation",
+    description: "Test automation and tooling",
+  },
+  {
+    slug: "python",
+    label: "Python",
+    description: "Python scripts, CLIs, and test helpers",
+  },
+  {
+    slug: "ci-cd",
+    label: "CI/CD",
+    description: "Pipelines, builds, and continuous integration",
+  },
+  {
+    slug: "appium",
+    label: "Appium",
+    description: "Mobile test automation",
+  },
+  {
+    slug: "photo",
+    label: "Photo",
+    description: "Photography and editing",
+  },
+  {
+    slug: "video",
+    label: "Video",
+    description: "Videography and post-production",
+  },
+  {
+    slug: "creative",
+    label: "Creative",
+    description: "Creative projects and craft",
+  },
+  {
+    slug: "personal",
+    label: "Personal",
+    description: "Reflections outside of work",
+  },
+  {
+    slug: "life",
+    label: "Life",
+    description: "Life updates and broader topics",
+  },
+  {
+    slug: "meta",
+    label: "Meta",
+    description: "Site and blog announcements",
+  },
+] as const;

--- a/src/data/nav.ts
+++ b/src/data/nav.ts
@@ -25,4 +25,10 @@ export const navItems: NavItem[] = [
     href: "#contact",
     icon: '<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" /></svg>',
   },
+  {
+    number: "",
+    label: "Blog",
+    href: "/blog/",
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z" /></svg>',
+  },
 ];

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -6,14 +6,22 @@ interface Props {
   title: string;
   description: string;
   canonicalPath: string;
+  ogType?: "website" | "article";
+  ogImage?: string;
 }
 
-const { title, description, canonicalPath } = Astro.props;
+const { title, description, canonicalPath, ogType, ogImage } = Astro.props;
 const site = Astro.site ?? new URL("https://avanegas.com");
 const canonicalUrl = new URL(canonicalPath, site).href;
 ---
 
-<Layout title={title} description={description} canonicalUrl={canonicalUrl}>
+<Layout
+  title={title}
+  description={description}
+  canonicalUrl={canonicalUrl}
+  ogType={ogType}
+  ogImage={ogImage}
+>
   <BlogHeader active="blog" />
   <main class="pt-[calc(var(--nav-height)+2rem)] pb-16 max-w-3xl mx-auto px-4 sm:px-6">
     <slot />

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -1,0 +1,21 @@
+---
+import BlogHeader from "@/components/blog/BlogHeader.astro";
+import Layout from "@/layouts/Layout.astro";
+
+interface Props {
+  title: string;
+  description: string;
+  canonicalPath: string;
+}
+
+const { title, description, canonicalPath } = Astro.props;
+const site = Astro.site ?? new URL("https://avanegas.com");
+const canonicalUrl = new URL(canonicalPath, site).href;
+---
+
+<Layout title={title} description={description} canonicalUrl={canonicalUrl}>
+  <BlogHeader active="blog" />
+  <main class="pt-[calc(var(--nav-height)+2rem)] pb-16 max-w-3xl mx-auto px-4 sm:px-6">
+    <slot />
+  </main>
+</Layout>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,16 +4,22 @@ import favicon from "@/assets/images/favicon.png";
 
 interface Props {
   title: string;
+  description?: string;
+  canonicalUrl?: string;
 }
 
-const { title } = Astro.props;
+const { title, description, canonicalUrl } = Astro.props;
+const metaDescription =
+  description ?? "Anderson Vanegas - SQA Engineer | Automation Engineer";
+const pageUrl = canonicalUrl ?? Astro.url.href;
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="description" content="Anderson Vanegas - SQA Engineer" />
+    <meta name="description" content={metaDescription} />
+    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
@@ -25,19 +31,16 @@ const { title } = Astro.props;
       property="og:image"
       content="https://avanegas.com/images/og.image.png"
     />
-    <meta property="og:title" content="Anderson Vanegas" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={metaDescription} />
+    <meta property="og:url" content={pageUrl} />
     <meta
-      property="og:description"
-      content="SQA Engineer | Automation Engineer"
+      property="og:type"
+      content={canonicalUrl?.includes("/blog/") ? "article" : "website"}
     />
-    <meta property="og:url" content="https://avanegas.com" />
-    <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Anderson Vanegas" />
-    <meta
-      name="twitter:description"
-      content="SQA Engineer | Automation Engineer"
-    />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={metaDescription} />
     <meta
       name="twitter:image"
       content="https://avanegas.com/images/og.image.png"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,12 +6,18 @@ interface Props {
   title: string;
   description?: string;
   canonicalUrl?: string;
+  ogType?: "website" | "article";
+  ogImage?: string;
 }
 
-const { title, description, canonicalUrl } = Astro.props;
+const DEFAULT_OG_IMAGE = "https://avanegas.com/images/og.image.png";
+
+const { title, description, canonicalUrl, ogType = "website", ogImage } =
+  Astro.props;
 const metaDescription =
   description ?? "Anderson Vanegas - SQA Engineer | Automation Engineer";
 const pageUrl = canonicalUrl ?? Astro.url.href;
+const socialImage = ogImage ?? DEFAULT_OG_IMAGE;
 ---
 
 <!doctype html>
@@ -27,24 +33,15 @@ const pageUrl = canonicalUrl ?? Astro.url.href;
     <link rel="icon" type="image/png" href={favicon.src} />
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
-    <meta
-      property="og:image"
-      content="https://avanegas.com/images/og.image.png"
-    />
+    <meta property="og:image" content={socialImage} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={metaDescription} />
     <meta property="og:url" content={pageUrl} />
-    <meta
-      property="og:type"
-      content={canonicalUrl?.includes("/blog/") ? "article" : "website"}
-    />
+    <meta property="og:type" content={ogType} />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={metaDescription} />
-    <meta
-      name="twitter:image"
-      content="https://avanegas.com/images/og.image.png"
-    />
+    <meta name="twitter:image" content={socialImage} />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/lib/blog-tags.ts
+++ b/src/lib/blog-tags.ts
@@ -1,0 +1,64 @@
+import type { CollectionEntry } from "astro:content";
+
+export type BlogPost = CollectionEntry<"blog">;
+
+export interface TagWithCount {
+  tag: string;
+  count: number;
+}
+
+export function normalizeTag(tag: string): string {
+  return tag.trim().toLowerCase().replace(/\s+/g, "-");
+}
+
+export function tagUrl(tag: string): string {
+  return `/blog/tags/${normalizeTag(tag)}`;
+}
+
+export function formatTagLabel(tag: string): string {
+  return normalizeTag(tag)
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function getPostsByTag(posts: BlogPost[], tag: string): BlogPost[] {
+  const normalized = normalizeTag(tag);
+  return posts
+    .filter((post) =>
+      post.data.tags.some((t) => normalizeTag(t) === normalized),
+    )
+    .sort(
+      (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
+    );
+}
+
+export function getAllTags(posts: BlogPost[]): TagWithCount[] {
+  const counts = new Map<string, number>();
+
+  for (const post of posts) {
+    for (const tag of post.data.tags) {
+      const normalized = normalizeTag(tag);
+      counts.set(normalized, (counts.get(normalized) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+}
+
+export function sortPostsByDate(posts: BlogPost[]): BlogPost[] {
+  return [...posts].sort(
+    (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
+  );
+}
+
+export function sortPostsFeaturedFirst(posts: BlogPost[]): BlogPost[] {
+  return [...posts].sort((a, b) => {
+    if (a.data.featured !== b.data.featured) {
+      return a.data.featured ? -1 : 1;
+    }
+    return b.data.pubDate.getTime() - a.data.pubDate.getTime();
+  });
+}

--- a/src/lib/blog-tags.ts
+++ b/src/lib/blog-tags.ts
@@ -1,3 +1,4 @@
+import { suggestedBlogTags } from "@/data/blog-tags";
 import type { CollectionEntry } from "astro:content";
 
 export type BlogPost = CollectionEntry<"blog">;
@@ -8,7 +9,13 @@ export interface TagWithCount {
 }
 
 export function normalizeTag(tag: string): string {
-  return tag.trim().toLowerCase().replace(/\s+/g, "-");
+  return tag
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
 }
 
 export function tagUrl(tag: string): string {
@@ -16,21 +23,29 @@ export function tagUrl(tag: string): string {
 }
 
 export function formatTagLabel(tag: string): string {
-  return normalizeTag(tag)
+  const normalized = normalizeTag(tag);
+  const known = suggestedBlogTags.find((t) => t.slug === normalized);
+  if (known) return known.label;
+
+  return normalized
     .split("-")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
 }
 
+export function sortPostsByDate(posts: BlogPost[]): BlogPost[] {
+  return [...posts].sort(
+    (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
+  );
+}
+
 export function getPostsByTag(posts: BlogPost[], tag: string): BlogPost[] {
   const normalized = normalizeTag(tag);
-  return posts
-    .filter((post) =>
+  return sortPostsByDate(
+    posts.filter((post) =>
       post.data.tags.some((t) => normalizeTag(t) === normalized),
-    )
-    .sort(
-      (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
-    );
+    ),
+  );
 }
 
 export function getAllTags(posts: BlogPost[]): TagWithCount[] {
@@ -46,12 +61,6 @@ export function getAllTags(posts: BlogPost[]): TagWithCount[] {
   return [...counts.entries()]
     .map(([tag, count]) => ({ tag, count }))
     .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
-}
-
-export function sortPostsByDate(posts: BlogPost[]): BlogPost[] {
-  return [...posts].sort(
-    (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime(),
-  );
 }
 
 export function sortPostsFeaturedFirst(posts: BlogPost[]): BlogPost[] {

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,70 @@
+---
+import BlogCoverImage from "@/components/blog/BlogCoverImage.astro";
+import TagPills from "@/components/blog/TagPills.astro";
+import BlogLayout from "@/layouts/BlogLayout.astro";
+import { getCollection, render } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog");
+  return posts.map((post) => ({
+    params: { slug: post.id },
+    props: post,
+  }));
+}
+
+const post = Astro.props as CollectionEntry<"blog">;
+const { Content } = await render(post);
+const formattedDate = post.data.pubDate.toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+const canonicalPath = `/blog/${post.id}/`;
+---
+
+<BlogLayout
+  title={`${post.data.title} | Anderson Vanegas`}
+  description={post.data.description}
+  canonicalPath={canonicalPath}
+>
+  <article class="fade-in">
+    <header class="mb-8 pb-8 border-b border-[#ffffff10]">
+      <a
+        href="/blog/"
+        class="text-sm text-[var(--sec)] hover:opacity-80 transition-opacity"
+      >
+        ← Back to blog
+      </a>
+      <time
+        datetime={post.data.pubDate.toISOString()}
+        class="block mt-4 text-sm text-[var(--white-icon)]"
+      >
+        {formattedDate}
+      </time>
+      <h1 class="mt-2 text-3xl sm:text-4xl font-bold text-[var(--white)]">
+        {post.data.title}
+      </h1>
+      <p class="mt-4 text-[var(--white-icon)] leading-relaxed">
+        {post.data.description}
+      </p>
+      <div class="mt-4">
+        <TagPills tags={post.data.tags} />
+      </div>
+    </header>
+
+    {
+      post.data.cover && (
+        <BlogCoverImage
+          src={post.data.cover.src}
+          alt={post.data.cover.alt}
+          caption="Cover image — sits between the post header and article body."
+        />
+      )
+    }
+
+    <div class="blog-prose">
+      <Content />
+    </div>
+  </article>
+</BlogLayout>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -21,12 +21,18 @@ const formattedDate = post.data.pubDate.toLocaleDateString("en-US", {
   day: "numeric",
 });
 const canonicalPath = `/blog/${post.id}/`;
+const site = Astro.site ?? new URL("https://avanegas.com");
+const ogImage = post.data.cover
+  ? new URL(post.data.cover.src, site).href
+  : undefined;
 ---
 
 <BlogLayout
   title={`${post.data.title} | Anderson Vanegas`}
   description={post.data.description}
   canonicalPath={canonicalPath}
+  ogType="article"
+  ogImage={ogImage}
 >
   <article class="fade-in">
     <header class="mb-8 pb-8 border-b border-[#ffffff10]">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -53,6 +53,12 @@ const tags = getAllTags(posts);
   }
 
   <section class="space-y-6" aria-label="Blog posts">
-    {posts.map((post) => <PostCard post={post} />)}
+    {
+      posts.length === 0 ? (
+        <p class="text-[var(--white-icon)] fade-in">No posts yet. Check back soon.</p>
+      ) : (
+        posts.map((post) => <PostCard post={post} />)
+      )
+    }
   </section>
 </BlogLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,58 @@
+---
+import PostCard from "@/components/blog/PostCard.astro";
+import BlogLayout from "@/layouts/BlogLayout.astro";
+import { getCollection } from "astro:content";
+import {
+  formatTagLabel,
+  getAllTags,
+  sortPostsFeaturedFirst,
+  tagUrl,
+} from "@/lib/blog-tags";
+
+const posts = sortPostsFeaturedFirst(await getCollection("blog"));
+const tags = getAllTags(posts);
+---
+
+<BlogLayout
+  title="Blog | Anderson Vanegas"
+  description="Notes on building reliable software and things I'm learning along the way."
+  canonicalPath="/blog/"
+>
+  <header class="mb-10 fade-in">
+    <p class="text-[var(--sec)] font-mono text-sm mb-2">Writing</p>
+    <h1 class="text-3xl sm:text-4xl font-bold text-[var(--white)] mb-4">
+      Blog
+    </h1>
+    <p class="text-[var(--white-icon)] leading-relaxed">
+      Notes on building reliable software and things I'm learning along the
+      way — QA, automation, creative projects, and life.
+    </p>
+  </header>
+
+  {
+    tags.length > 0 && (
+      <section class="mb-10 fade-in" aria-label="All tags">
+        <h2 class="text-sm text-[var(--white-icon)] mb-3 uppercase tracking-wide">
+          Topics
+        </h2>
+        <ul class="flex flex-wrap gap-2 list-none p-0 m-0">
+          {tags.map(({ tag, count }) => (
+            <li>
+              <a
+                href={tagUrl(tag)}
+                class="inline-flex items-center gap-1.5 px-3 py-1 text-xs border border-[#ffffff20] text-[var(--white-icon)] rounded-full hover:border-[var(--sec)] hover:text-[var(--sec)] transition-colors duration-300"
+              >
+                {formatTagLabel(tag)}
+                <span class="text-[var(--white-icon)]/70">({count})</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    )
+  }
+
+  <section class="space-y-6" aria-label="Blog posts">
+    {posts.map((post) => <PostCard post={post} />)}
+  </section>
+</BlogLayout>

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,0 +1,58 @@
+---
+import PostCard from "@/components/blog/PostCard.astro";
+import BlogLayout from "@/layouts/BlogLayout.astro";
+import { getCollection } from "astro:content";
+import type { BlogPost } from "@/lib/blog-tags";
+import {
+  formatTagLabel,
+  getAllTags,
+  getPostsByTag,
+  normalizeTag,
+} from "@/lib/blog-tags";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog");
+  const tags = getAllTags(posts);
+
+  return tags.map(({ tag }) => ({
+    params: { tag },
+    props: { tag, posts: getPostsByTag(posts, tag) },
+  }));
+}
+
+interface Props {
+  tag: string;
+  posts: BlogPost[];
+}
+
+const { tag, posts } = Astro.props;
+const label = formatTagLabel(tag);
+const canonicalPath = `/blog/tags/${normalizeTag(tag)}/`;
+---
+
+<BlogLayout
+  title={`${label} | Blog | Anderson Vanegas`}
+  description={`Posts tagged with ${label}.`}
+  canonicalPath={canonicalPath}
+>
+  <header class="mb-10 fade-in">
+    <a
+      href="/blog/"
+      class="text-sm text-[var(--sec)] hover:opacity-80 transition-opacity"
+    >
+      ← Back to blog
+    </a>
+    <p class="text-[var(--sec)] font-mono text-sm mt-4 mb-2">Topic</p>
+    <h1 class="text-3xl sm:text-4xl font-bold text-[var(--white)] mb-2">
+      {label}
+    </h1>
+    <p class="text-[var(--white-icon)]">
+      {posts.length}
+      {posts.length === 1 ? "post" : "posts"}
+    </p>
+  </header>
+
+  <section class="space-y-6" aria-label={`Posts tagged ${label}`}>
+    {posts.map((post) => <PostCard post={post} />)}
+  </section>
+</BlogLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -117,3 +117,71 @@
 .fade-in--slow.visible {
   transform: translateY(0);
 }
+
+/* Blog post prose */
+.blog-prose {
+  color: var(--white-icon);
+  line-height: 1.75;
+}
+
+.blog-prose h2 {
+  color: var(--white);
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.blog-prose h3 {
+  color: var(--white);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.blog-prose p {
+  margin-bottom: 1rem;
+}
+
+.blog-prose ul,
+.blog-prose ol {
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
+.blog-prose li {
+  margin-bottom: 0.5rem;
+}
+
+.blog-prose a {
+  color: var(--sec);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.blog-prose a:hover {
+  opacity: 0.85;
+}
+
+.blog-prose strong {
+  color: var(--white);
+  font-weight: 600;
+}
+
+.blog-prose code {
+  background: var(--white-icon-tr);
+  color: var(--sec);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-size: 0.9em;
+}
+
+.blog-prose img {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin: 1.5rem 0;
+  border-radius: 0.5rem;
+  border: 1px solid #ffffff10;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -169,12 +169,20 @@
   font-weight: 600;
 }
 
-.blog-prose code {
+.blog-prose :not(pre) > code {
   background: var(--white-icon-tr);
   color: var(--sec);
   padding: 0.125rem 0.375rem;
   border-radius: 0.25rem;
   font-size: 0.9em;
+}
+
+.blog-prose pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
 }
 
 .blog-prose img {


### PR DESCRIPTION
## Summary
- Adds Astro content collection, tag helpers, blog layout/components, and `/blog` routes
- Adds Blog links in portfolio nav and footer
- Improves `Layout.astro` meta tags (description, canonical URL, dynamic OG tags)
- **No markdown posts included** — `/blog` renders an empty index; no post or tag pages are generated

## Test plan
- [ ] `npm run build` succeeds with empty `src/content/blog/`
- [ ] `/blog/` loads and shows empty post list
- [ ] No routes exist for `/blog/<slug>/` or `/blog/tags/<tag>/`
- [ ] Portfolio nav/footer Blog link works

## Follow-up
Posts will land in a separate PR (`blog-posts`) after content is rewritten.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full blog section with an index page, individual post pages, and tag-filtered views.
  * Introduced reusable blog components (post cards, cover images, tag pills, and a blog header) plus navigation and footer blog links.
  * Added blog content support with tag-based organization and featured-post ordering.

* **Bug Fixes**
  * Improved SEO/social metadata for blog pages (including dynamic Open Graph/Twitter tags and canonical URLs).
  * Added polished blog typography and responsive article image styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->